### PR TITLE
Edited UserGetDTO and DTOMapper to get startTime and duration

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -20,5 +20,7 @@ public class UserGetDTO {
   private LocalDate birthday;
   private String timezone;
   private String profilePicture;
+  private String startTime;
+  private String duration;
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -52,6 +52,8 @@ public interface DTOMapper {
   @Mapping(source = "birthday", target = "birthday")
   @Mapping(source = "timezone", target = "timezone")
   @Mapping(source = "profilePicture", target = "profilePicture")
+  @Mapping(source = "startTime", target = "startTime")
+  @Mapping(source = "duration", target = "duration")
   UserGetDTO convertEntityToUserGetDTO(User user);
 
   @Mapping(source = "startTime", target = "startTime")


### PR DESCRIPTION
Added startTime and duration to the UserGetDTO and adjusted the DTOMapper accordingly. This is to ensure the time remaining display on the group page renders correctly once a user loads the page.